### PR TITLE
MAIN-14727: modify go-logging to truncate log entries exceeding 1Kb

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -33,7 +33,14 @@ func NewSyslogBackendPriority(prefix string, priority syslog.Priority) (b *Syslo
 
 // Log implements the Backend interface.
 func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
+	const logEntrySize = 1024 // bytes
 	line := rec.Formatted(calldepth + 1)
+
+	if len(line) > logEntrySize {
+		b := []byte(line)
+		line = string(b[:logEntrySize+1])
+	}
+
 	switch level {
 	case CRITICAL:
 		return b.Writer.Crit(line)


### PR DESCRIPTION
This change was manually tested by creating a go program, which imported the modified go-logging package, to generate a log entry that would exceed 1Kb. This go program was then shipped to a sandbox and run while observing syslog and verifying that the log entry was truncated.
