### PR TITLE
MAIN-18552 - log line length limit larger

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -33,7 +33,7 @@ func NewSyslogBackendPriority(prefix string, priority syslog.Priority) (b *Syslo
 
 // Log implements the Backend interface.
 func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
-	const logEntrySize = 1024 // bytes
+	const logEntrySize = 1997 // bytes. This is the longest log line that we can print
 	line := rec.Formatted(calldepth + 1)
 
 	if len(line) > logEntrySize {


### PR DESCRIPTION
I ran a test where I turned off the log line truncate logic and attempted to log lines of varying lengths. I found that 1024 characters prints correctly, but if we try to do more than that the log line gets truncated to 1997 characters. Somewhere between 65536 and 131072 characters, log lines just start getting dropped entirely. This suggests that we should update the 1024 character limit to 1997.