### PR TITLE
MAIN-18552 - use a less precise number to denote arbitrariness

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -33,7 +33,7 @@ func NewSyslogBackendPriority(prefix string, priority syslog.Priority) (b *Syslo
 
 // Log implements the Backend interface.
 func (b *SyslogBackend) Log(level Level, calldepth int, rec *Record) error {
-	const logEntrySize = 1997 // bytes. This is the longest log line that we can print
+	const logEntrySize = 2048 // bytes. This prevents very large messages from being dropped
 	line := rec.Formatted(calldepth + 1)
 
 	if len(line) > logEntrySize {


### PR DESCRIPTION
The number 1997 was fairly arbitrary. It's the largest log line that we've observed being able to print, but there's nothing intrinsic about it that should make it the cutoff. In order to denote that the number is arbitrary, change it to a nice round number like 2048. These lines will still get truncated to ~1997 characters, but are small enought that they won't get dropped, so this does not have any functional consequences.